### PR TITLE
Handle dot notation when calling function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ LIBLUA = build/lua-$(LUA_BUILD)/install/lib/liblua.a
 YDB_INCLUDES = $(shell pkg-config --cflags yottadb)
 LUA_INCLUDES = -Ibuild/lua-$(LUA_BUILD)/install/include
 LUA_YOTTADB_INCLUDES = -I../lua-$(LUA_BUILD)/install/include
-LUA_YOTTADB_CFLAGS = -fPIC -std=c11 -pedantic -Wall -Wno-unknown-pragmas -Wno-discarded-qualifiers $(YDB_INCLUDES) $(LUA_YOTTADB_INCLUDES)
-CFLAGS = -fPIC -std=c11 -pedantic -Wall -Wno-unknown-pragmas  $(YDB_INCLUDES) $(LUA_INCLUDES)
+LUA_YOTTADB_CFLAGS = -fPIC -std=c11 -pedantic -Wall -Werror -Wno-unknown-pragmas -Wno-discarded-qualifiers $(YDB_INCLUDES) $(LUA_YOTTADB_INCLUDES)
+CFLAGS = -fPIC -std=c11 -pedantic -Wall -Werror -Wno-unknown-pragmas  $(YDB_INCLUDES) $(LUA_INCLUDES)
 LDFLAGS = -lm -ldl -lyottadb -L$(YDB_DIST) -Wl,-rpath,$(YDB_DIST),--library-path=build/lua-$(LUA_BUILD)/install/lib,-l:liblua.a
 CC = gcc
 # bash and GNU sort required for LUA_BUILD version comparison

--- a/README.md
+++ b/README.md
@@ -234,9 +234,10 @@ Be aware that since different versions of Lua act differently, MLua will also ac
 1. Number parameters are passed as strings, and returned as strings using Lua's number conversion, e.g.:
 
    ```lua
-   $&mlua.lua("return select(1, ...) + select(2, ...)",.output,,3,4) w output
+   YDB>do &mlua.lua("function add(a,b) return a+b end")
+   YDB>do &mlua.lua(">add",.out,,3,4) w out
+   7
    ```
-
 
    This outputs "7" for all Lua versions except Lua 5.3, which returns "7.0". This is because all numbers are passed as strings, and Lua < 5.4 converts strings to floats but Lua < 5.3 prints floats without the `.0` if possible, whereas Lua 5.3 prints floats with the `.0` And Lua >5.3 (e.g. 5.4) recognises strings '3' and '4' as integers, not floats: so its sum produces an integer as string "7".
 

--- a/tests/unittest.m
+++ b/tests/unittest.m
@@ -62,9 +62,9 @@ testBasics()
  do assert(expected,output)
  do assert("",$$lua(""))
  do assert(1,0'=$&mlua.lua(">",.output))
- do assert("Lua: could not find global function ''",output)
+ do assert("Lua: could not find function ''",output)
  do assert(1,0'=$&mlua.lua(">unknown_func",.output))
- do assert("Lua: could not find global function 'unknown_func'",output)
+ do assert("Lua: could not find function 'unknown_func'",output)
  quit
 
 testParameters()


### PR DESCRIPTION
Handle dot notation calling function: &mlua.lua(">math.abs",.output,-3")