### PR TITLE
Luastate handle safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,10 @@ On error, `mlua.lua()` returns nonzero and the error message is sent to stdout o
 
 **`mlua.open()`** creates a new 'lua_State' which contains a new Lua context, stack, and global variables, and can run independently and in parallel with other lua_States (see the Lua Reference Manual on the [Application Programmer Interface](https://www.lua.org/manual/5.4/manual.html#4)). On success, `mlua.open()` returns a luaState handle which can be passed to mlua.lua(). On error, it returns zero and the error message is sent to stdout or returned in .output if supplied.
 
-**`mlua.close()`** can be called if you have finished using the lua_State, in order to free up any memory that a lua_State has allocated, first calling any garbage-collection meta-methods you have introduced in Lua. It returns nothing, and cannot produce an error.
+**`mlua.close()`** can be called if you have finished using the lua_State, in order to free up any memory that a lua_State has allocated, first calling any garbage-collection meta-methods you have introduced in Lua.
+`mlua.close(0)` will close the default Lua state, and 
+`mlua.close()` will close all Lua states.
+It returns 0 on success, -1 if the supplied handle is invalid, and -2 if the supplied handle is already closed.
 
 ### Signals / Interrupts
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Here is the list of supplied functions, [optional parameters in square brackets]
 
 Be aware that all parameters are strings and are not automatically converted to Lua numbers. Parameters are currently limited to 8, but this may easily be increased in mlua.xc.
 
-On success, `mlua.lua()` fills .output (if given) with the return value of the code chunk. If only one parameter is supplied, output will go to stdout). If the return value is not a string, it is encoded as follows:
+On success, `mlua.lua()` sends the returned string to stdout or fills .output (if >1 parameters are supplied). If the return value is not a string, it is converted to a string as follows:
 
 * nil ==> "" (empty string)
 * boolean ==> "0" or "1"
@@ -135,9 +135,9 @@ On success, `mlua.lua()` fills .output (if given) with the return value of the c
 
 If the luaState handle is missing or 0, mlua.lua() will run the code in the default global lua_State, automatically opening it the first time you call mlua.lua(). Alternatively, you can supply a luaState with a handle returned by mlua.open() (see below) to run code in a different lua_State.
 
-On error, `mlua.lua()` returns nonzero and the error message is returned in .output (if >1 parameter supplied) or sent to stdout. Note that the error value return is currently equal to -1. This may be enhanced in the future to also return positive integers equal to ERRNO or YDB errors whenever YDB functions called by Lua are the cause of the error. However, for now, all errors return -1 and any YDB error code is encoded into the error message just like any other Lua error (Lua 5.4 does not yet support coded or named errors).
+On error, `mlua.lua()` returns nonzero and the error message is sent to stdout or returned in .output (if >1 parameter supplied). Note that the error value return is currently equal to -1. This may be enhanced in the future to also return positive integers equal to ERRNO or YDB errors whenever YDB functions called by Lua are the cause of the error. However, for now, all errors return -1 and any YDB error code is encoded into the error message just like any other Lua error (Lua 5.4 does not yet support coded or named errors).
 
-**`mlua.open()`** creates a new 'lua_State' which contains a new Lua context, stack, and global variables, and can run independently and in parallel with other lua_States (see the Lua Reference Manual on the [Application Programmer Interface](https://www.lua.org/manual/5.4/manual.html#4)). On success, `mlua.open()` returns a luaState handle which can be passed to mlua.lua(). On error, it returns zero and the error message is returned in .output (if >0 parameters are given) or sent to stdout.
+**`mlua.open()`** creates a new 'lua_State' which contains a new Lua context, stack, and global variables, and can run independently and in parallel with other lua_States (see the Lua Reference Manual on the [Application Programmer Interface](https://www.lua.org/manual/5.4/manual.html#4)). On success, `mlua.open()` returns a luaState handle which can be passed to mlua.lua(). On error, it returns zero and the error message is sent to stdout or returned in .output if supplied.
 
 **`mlua.close()`** can be called if you have finished using the lua_State, in order to free up any memory that a lua_State has allocated, first calling any garbage-collection meta-methods you have introduced in Lua. It returns nothing, and cannot produce an error.
 

--- a/mlua.c
+++ b/mlua.c
@@ -103,7 +103,7 @@ gtm_long_t mlua_open(int argc, gtm_string_t *output, gtm_int_t flags) {
     if (State_array->used >= State_array->size) {
       State_array = realloc(State_array, sizeof(state_array_t) + (State_array->size+STATE_ARRAY_LUMPS) * sizeof(lua_State*));
       if (!State_array)
-        return outputf(output, output_size, "MLua: Could not allocate lua_State -- possible memory lack"), 0;
+        return outputf(output, output_size, "MLua: Could not allocate memory for lua_State"), 0;
       State_array->size += STATE_ARRAY_LUMPS;
     }
     handle = State_array->used;

--- a/mlua.h
+++ b/mlua.h
@@ -21,7 +21,7 @@ gtm_int_t mlua(int argc, const gtm_string_t *code, gtm_string_t *outstr, gtm_lon
 gtm_long_t mlua_open(int argc, gtm_string_t *outstr, gtm_int_t flags);
 
 // close lua_State specified by lua_handle (which may be 0 for the global lua_State)
-void mlua_close(int argc, gtm_long_t lua_handle);
+gtm_int_t mlua_close(int argc, gtm_long_t lua_handle);
 
 // return MLUA_VERSION_NUMBER XXYYZZ where XX=major; YY=minor; ZZ=release
 gtm_int_t mlua_version_number(int _argc);

--- a/mlua.h
+++ b/mlua.h
@@ -7,6 +7,7 @@
 
 // Flags that may be passed to the optional flags parameter of mlua_open()
 #define MLUA_IGNORE_INIT 1  /* Do not process code pointed to by MLUA_INIT environment variable */
+#define MLUA_OPEN_DEFAULT 2  /* Used internally to specify opening the default Lua state */
 
 // use a value that is not used by YDB or ERRNO in case we decide to return those errors at some later point.
 #define MLUA_ERROR -1

--- a/mlua.h
+++ b/mlua.h
@@ -5,7 +5,7 @@
 
 #include "gtmxc_types.h"
 
-// Flags that may be passed to the optional flags parameter of mlua_open()
+// Bitfield of flags that may be passed to the optional flags parameter of mlua_open()
 #define MLUA_IGNORE_INIT 1  /* Do not process code pointed to by MLUA_INIT environment variable */
 #define MLUA_OPEN_DEFAULT 2  /* Used internally to specify opening the default Lua state */
 

--- a/mlua.xc
+++ b/mlua.xc
@@ -1,6 +1,6 @@
 $ydb_dist/plugin/mlua.so
 
 lua: gtm_int_t mlua_lua( I:gtm_string_t*, O:gtm_string_t* [1048576], I:gtm_long_t, I:gtm_string_t*, I:gtm_string_t*, I:gtm_string_t*, I:gtm_string_t*, I:gtm_string_t*, I:gtm_string_t*, I:gtm_string_t*, I:gtm_string_t* )
-open: ydb_long_t mlua_open( O:gtm_string_t* [2049], I:gtm_int_t )
-close: void mlua_close( I:gtm_long_t ) : sigsafe
-version:  ydb_int_t mlua_version_number() : sigsafe
+open: gtm_long_t mlua_open( O:gtm_string_t* [2049], I:gtm_int_t )
+close: gtm_int_t mlua_close( I:gtm_long_t ) : sigsafe
+version:  gtm_int_t mlua_version_number() : sigsafe

--- a/tests/unittest.m
+++ b/tests/unittest.m
@@ -139,6 +139,7 @@ testInit()
 
 testLuaState()
  new newState,output
+ ;Check that globals are distinct between Lua states
  do lua("test=3")
  do assert("3",$$lua("return test"))
  set newState=$&mlua.open()


### PR DESCRIPTION
Provide safety checks on state handles to avoid segfaults when user supplies an incorrect state handle, which is an easy mistake to make. Instead, provide a suitable error message.