### PR TITLE
Better fix of MLua build to work when YottaDB is in UTF-8 mode that now also works in benchmarks/Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,11 +235,9 @@ export LUA_CPATH:=./?.so;$(LUA_CPATH)
 export LUA_INIT:=
 #used to check that MLUA_INIT works:
 export MLUA_INIT:=inittest=1
+utf8:=$(if $(findstring -8,$(if $(ydb_chset),$(ydb_chset),$(gtm_chset))),/utf8)
+export ydb_routines:=tests $(ydb_dist)$(utf8)/libyottadbutil.so
 export ydb_xc_mlua:=tests/mlua.xc
-
-
-utf8:=$(shell echo $(ydb_chset) | grep -qi UTF-8 && echo utf8/)
-export ydb_routines:=tests $(ydb_dist)/$(utf8)libyottadbutil.so
 
 TMPDIR ?= /tmp
 tmpgld = $(TMPDIR)/mlua-test

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -19,9 +19,8 @@ export LUA_CPATH:=../?.so;./?.so;$(LUA_CPATH)
 export LUA_INIT:=
 export MLUA_INIT:=
 export ydb_xc_cstrlib:=./cstrlib.xc
-#read gtmroutines below instead of ydb_routines since we want the original ydb_routines even when propagated from parent MAKE
-#otherwise ydb complains about format issues (I haven't figured out what it means)
-export ydb_routines:=. $(gtmroutines)
+utf8:=$(if $(findstring -8,$(if $(ydb_chset),$(ydb_chset),$(gtm_chset))),/utf8)
+export ydb_routines:=. $(ydb_dist)$(utf8)/libyottadbutil.so
 export ydb_xc_mlua:=mlua.xc
 
 #Location of temporary database for benchmarking


### PR DESCRIPTION
Also removes the cludgy gtmroutines hack-fix from benchmarks/Makefile because, although I can't remember the original error, I suspect this fix will also fix that problem. It seems to work.